### PR TITLE
dict keys should be sorted before encode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ coveralls:
 test:
 	go test -v -race
 
+test-dict-encode:
+	richgo test -v --count=1000 -run=TestMarshalUnOrderedDict
+
 bench:
 	go test -v -bench=. -run "^Benchmark"
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ import bencode "github.com/IncSW/go-bencode"
 ## Quick Start
 
 ```go
-data, err := Marshal(value)
+data, err := bencode.Marshal(value)
 ```
 
 ```go
-data, err := Unmarshal(value)
+data, err := bencode.Unmarshal(value)
 ```
 
 ## Performance

--- a/marshaler.go
+++ b/marshaler.go
@@ -2,6 +2,7 @@ package bencode
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 )
 
@@ -164,10 +165,16 @@ func marshalDictionary(data map[string]interface{}, result *[]byte, offset int, 
 	(*result)[offset] = 'd'
 	offset++
 
-	for key, data := range data {
+	keys := make([]string, 0, len(data))
+	for key, _ := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		offset, length = marshalBytes(s2b(key), result, offset, length)
 		var err error
-		offset, length, err = marshal(data, result, offset, length)
+		offset, length, err = marshal(data[key], result, offset, length)
 		if err != nil {
 			return 0, 0, err
 		}

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -58,6 +58,18 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
+func TestMarshalUnOrderedDict(t *testing.T) {
+	assert := assert.New(t)
+	unorderedEncodedData := []byte(`d7:ttg_tag32:8032a74ec22927a5bd6367537eafd87e7:privatei1e6:source20:[ttys3.bencode.test]e`)
+	expectedReencodedData := []byte(`d7:privatei1e6:source20:[ttys3.bencode.test]7:ttg_tag32:8032a74ec22927a5bd6367537eafd87ee`)
+	data, err := Unmarshal(unorderedEncodedData)
+	assert.NoError(err)
+	//t.Logf("decoded data: %#v", data)
+	reencoded, err := Marshal(data)
+	assert.NoError(err)
+	assert.Equal(expectedReencodedData, reencoded)
+}
+
 func BenchmarkMarshal(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {


### PR DESCRIPTION
according to BEP003 http://bittorrent.org/beps/bep_0003.html#bencoding

bencoded dictionary keys MUST be sorted as raw strings, not alphanumerics

> Dictionaries are encoded as a 'd' followed by a list of alternating keys and their corresponding values followed by an 'e'. For example, d3:cow3:moo4:spam4:eggse corresponds to {'cow': 'moo', 'spam': 'eggs'} and d4:spaml1:a1:bee corresponds to {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order (sorted as raw strings, not alphanumerics).

see also https://github.com/Frederick888/php-bencode/issues/7
https://github.com/Frederick888/php-bencode/pull/8